### PR TITLE
change to AnyFunSuite to get rid of deprecated FunSuite

### DIFF
--- a/src/main/g8/src/test/scala/CubeCalculatorTest.scala
+++ b/src/main/g8/src/test/scala/CubeCalculatorTest.scala
@@ -1,4 +1,4 @@
-class CubeCalculatorTest extends org.scalatest.FunSuite {
+class CubeCalculatorTest extends org.scalatest.funsuite.AnyFunSuite {
   test("CubeCalculator.cube") {
     assert(CubeCalculator.cube(3) === 27)
   }


### PR DESCRIPTION
There was a warning when using org.scalatest.FunSuite:

```
[warn] /Users/xyz/Git/private/scala/scala-test/src/test/scala/CubeCalculatorTest.scala:3:34: type FunSuite in package scalatest is deprecated (since 3.1.0): The org.scalatest.FunSuite trait ha
s been moved and renamed. Please use org.scalatest.funsuite.AnyFunSuite instead. This can be rewritten automatically with autofix: https://github.com/scalatest/autofix/tree/master/3.1.x
```
Thus I suggest to use the newer package.