### PR TITLE
make Scala 3 the default version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A [Giter8][g8] template for trying out ScalaTest, used in the [Getting Started w
  - Run this in the sbt console:
  `sbt new scala/scalatest-example.g8`
  - When prompted for name, enter any name you want
-    - For example : 'hello
+    - For example : 'hello'
       ....
       Template applied in ./hello
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 A [Giter8][g8] template for trying out ScalaTest, used in the [Getting Started with Scala guide](https://docs.scala-lang.org/getting-started-sbt-track/testing-scala-with-sbt-on-the-command-line.html).
 
 ##### To create the project using this template:
- - Run this in the sbt console: 
+ - Run this in the sbt console:
  `sbt new scala/scalatest-example.g8`
  - When prompted for name, enter any name you want
-    - For example : 'hello'  
-      ....  
+    - For example : 'hello
+      ....
       Template applied in ./hello
-    
+
 Template license
 ----------------
-Written in 2017-2021 by the Scala Center
+Written in 2017-2024 by the Scala Center
 
 To the extent possible under law, the author(s) have dedicated all copyright and related
 and neighboring rights to this template to the public domain worldwide.

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -1,5 +1,5 @@
 name=My Something Project
 description=Say something about this template.
 package=com.example
-scala-version=2.13.15
+scala-version=3.5.2
 scalatest-version=3.2.19

--- a/src/main/g8/src/main/scala/$package$/CubeCalculator.scala
+++ b/src/main/g8/src/main/scala/$package$/CubeCalculator.scala
@@ -1,5 +1,4 @@
-object CubeCalculator extends App {
-  def cube(x: Int) = {
+object CubeCalculator {
+  def cube(x: Int): Int =
     x * x * x
-  }
 }


### PR DESCRIPTION
but the code is also still valid Scala 2 code so if someone explicitly chooses Scala 2 instead, that's okay

I removed `extends App` because it plays no role and because it's problematic in Scala 3
